### PR TITLE
Fix indentention in test_main_ls_no_files().

### DIFF
--- a/tests/test_microfs.py
+++ b/tests/test_microfs.py
@@ -615,9 +615,9 @@ def test_main_ls_no_files():
     with mock.patch('microfs.ls', return_value=[]) as mock_ls, \
             mock.patch('microfs.get_serial', return_value=mock_class), \
             mock.patch.object(builtins, 'print') as mock_print:
-            microfs.main(argv=['ls'])
-            mock_ls.assert_called_once_with()
-            assert mock_print.call_count == 0
+        microfs.main(argv=['ls'])
+        mock_ls.assert_called_once_with()
+        assert mock_print.call_count == 0
 
 
 def test_main_rm():


### PR DESCRIPTION
The tests were throwing this error:

```
$ make check                        
rm -rf build
rm -rf dist
rm -rf microfs.egg-info
rm -rf .coverage
rm -rf docs/_build
find . \( -name '*.py[co]' -o -name dropin.cache \) -print0 | xargs -0  rm
find . \( -name '*.bak' -o -name dropin.cache \) -print0 | xargs -0  rm
find . \( -name '*.tgz' -o -name dropin.cache \) -print0 | xargs -0  rm
find . \( -name _build -o -name var \) -type d -prune -o -name '*.py' -print0 | xargs -0  -n 1 pycodestyle --repeat --exclude=build/*,docs/*,setup.py --ignore=E731,E402
./tests/test_microfs.py:618:13: E117 over-indented
make: *** [pycodestyle] Error 1
```