### PR TITLE
Add Travis CI configuration file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+# Ubuntu 16.04 required for Python >= 3.7
+dist: xenial
+language: python
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+install:
+  - pip install -r requirements.txt
+  - python setup.py develop
+script:
+  - make check


### PR DESCRIPTION
PR to get CI tests running, all you'd need to do after merging this PR is to enable this repository in https://travis-ci.org .

At the moment the tests are failing due to https://github.com/ntoll/microfs/pull/13, but you can see the current (failing) results at my fork:
https://travis-ci.org/carlosperate/microfs/builds/520279169