### PR TITLE
Added optional delimiter for ls command

### DIFF
--- a/microfs.py
+++ b/microfs.py
@@ -345,7 +345,7 @@ def main(argv=None):
         parser = argparse.ArgumentParser(description=_HELP_TEXT)
         parser.add_argument(
             "command",
-            nargs="?",
+            nargs="+",
             default=None,
             help="One of 'ls', 'rm', 'put' or 'get'.",
         )
@@ -362,10 +362,15 @@ def main(argv=None):
             help="Use to specify a target filename.",
         )
         args = parser.parse_args(argv)
-        if args.command == "ls":
-            list_of_files = ls()
-            if list_of_files:
-                print(" ".join(list_of_files))
+        if type(args.command) is list:
+            if args.command[0] == "ls":
+                list_of_files = ls()
+                # get optional second parameter as delimiter
+                delim = ' '  # default it as space ' '
+                if len(args.command) > 1:
+                    delim = args.command[1]
+                if list_of_files:
+                    print(delim.join(list_of_files))
         elif args.command == "rm":
             if args.path:
                 rm(args.path)


### PR DESCRIPTION
This features allows to _optionally_ pass an additional parameter for the command `ls`, specifying a delimiter to be used when printing on the standard output the files stored on the micro:bit. This feature is optional, meaning that it won't affect the current behavior of the software when a delimiter is not specified (i.e. it is back-compatible and should not break any code that depends on the current behavior of microfs).

## The issue
In the current version of microfs, the files stored on the micro:bit are listed separated by a whitespace (' ') delimiter. This is problematic/confusing if a user uploads on the micro:bit files that have a white space in the name itself. *For example*, if a user upload (i.e. with `put`) the files **main.py** and **my file.py**, the command `python microfs ls`  prints on the console `main.py my file.py`. This behavior can lead to confusion (e.g., it looks like there are three files on the file system) and makes difficult to create automation tools that rely on correctly listing the files.

## The solution
To solve this problem we can introduce an optional parameter following the `ls` command. If not specified, white space (' ') is chosen as default, leaving the behavior of microfs as in the current version. Alternatively the user can input a string delimiter. Following the example above, we could run now the command `python microfs ls ,` and the output would be `main.py,my file.py` - which is less ambiguous than the output shown before.

## Example usage

Assuming the files A, B, and C stored on the micro:bit

`python microfs ls` => A B C
`python microfs ls ' '` => same as above => A B C
`python microfs ls ,` => A,B,C
`python microfs ls ','` => A,B,C
`python microfs ls ';'` => A;B;C