### PR TITLE
Added optional delimiter for `ls` command

### DIFF
--- a/microfs.py
+++ b/microfs.py
@@ -342,30 +342,36 @@ def main(argv=None):
     try:
         global COMMAND_LINE_FLAG
         COMMAND_LINE_FLAG = True
+
         parser = argparse.ArgumentParser(description=_HELP_TEXT)
-        parser.add_argument(
-            "command",
-            nargs="?",
-            default=None,
-            help="One of 'ls', 'rm', 'put' or 'get'.",
-        )
-        parser.add_argument(
-            "path",
-            nargs="?",
-            default=None,
-            help="Use when a file needs referencing.",
-        )
-        parser.add_argument(
-            "target",
-            nargs="?",
-            default=None,
-            help="Use to specify a target filename.",
-        )
-        args = parser.parse_args(argv)
+        subparsers = parser.add_subparsers(
+            dest='command', help="One of 'ls', 'rm', 'put', 'get', or reset.")
+
+        ls_parser = subparsers.add_parser("ls")
+        ls_parser.add_argument("delimiter", nargs="?", default=' ',
+                               help="Specify a delimiter string (default is whitespace). Eg. \";\"")
+
+        rm_parser = subparsers.add_parser("rm")
+        rm_parser.add_argument(
+            "path", nargs="?", help="Specify a target filename.")
+
+        get_parser = subparsers.add_parser("get")
+        get_parser.add_argument(
+            "path", nargs="?", help="Use when a file needs referencing.")
+        get_parser.add_argument("target", nargs="?",
+                                help="Specify a target filename.")
+
+        put_parser = subparsers.add_parser("put")
+        put_parser.add_argument(
+            "path", nargs="?", help="Use when a file needs referencing.")
+        put_parser.add_argument("target", nargs="?",
+                                help="Specify a target filename.")
+
+        args = parser.parse_args(argv) 
         if args.command == "ls":
             list_of_files = ls()
             if list_of_files:
-                print(" ".join(list_of_files))
+                print(args.delimiter.join(list_of_files))
         elif args.command == "rm":
             if args.path:
                 rm(args.path)

--- a/microfs.py
+++ b/microfs.py
@@ -345,7 +345,7 @@ def main(argv=None):
 
         parser = argparse.ArgumentParser(description=_HELP_TEXT)
         subparsers = parser.add_subparsers(
-            dest='command', help="One of 'ls', 'rm', 'put', 'get', or reset.")
+            dest='command', help="One of 'ls', 'rm', 'put' or 'get'")
 
         ls_parser = subparsers.add_parser("ls")
         ls_parser.add_argument("delimiter", nargs="?", default=' ',


### PR DESCRIPTION
This features allows to _optionally_ pass an additional parameter for the command `ls`, specifying a **delimiter** to be used when printing on the standard output the files stored on the micro:bit. This feature is optional, meaning that it won't affect the current behavior of the software when a delimiter is not specified (i.e. it is back-compatible and should not break any code that depends on the current behavior of microfs). I verified that it does not break any test.

## The issue
In the current version of microfs, the files stored on the micro:bit are listed separated by a whitespace (' ') delimiter. This is problematic/confusing if a user uploads on the micro:bit files that have a white space in the name itself. *For example*, if a user upload (i.e. with `put`) the files **main.py** and **my file.py**, the command `python microfs ls`  prints on the console `main.py my file.py`. This behavior can lead to confusion (e.g., it looks like there are three files on the file system) and makes difficult to create automation tools that rely on correctly listing the files.

## The solution
To solve this problem we can introduce an optional parameter following the `ls` command. If not specified, white space (' ') is chosen as default, leaving the behavior of microfs as in the current version. Alternatively the user can input a string delimiter. Following the example above, we could run now the command `python microfs ls ,` and the output would be `main.py,my file.py` - which is less ambiguous than the output shown before.

## Example usage

Assuming the files A, B, and C stored on the micro:bit

```
python microfs ls => results in "A B C"
python microfs ls ' ' => same as above => "A B C"
python microfs ls , => "A,B,C"
python microfs ls ',' => "A,B,C"
python microfs ls ';' => "A;B;C"
python microfs ls ';%;' => "A;%;B;%;C"
```
## Known issues

Due to how [argparse](https://docs.python.org/3/library/argparse.html) works, there are restrictions on the choice of delimiter. For example, the following code would result in an error:

`python microfs ls '---'` => error: unrecognized arguments: ----

but this would be ok
`python microfs ls '- '` => would print A-B-C