### PR TITLE
Adding test for ls with delimiter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,11 @@ List the files on the device::
 
     $ ufs ls
 
+You can also specify a delimiter (default is whitespace ' ') to separte file names on the output::
+
+    # use ';' as a delimiter
+    $ ufs ls ';'
+
 Delete a file on the device::
 
     $ ufs rm foo.txt

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ List the files on the device::
 
     $ ufs ls
 
-You can also specify a delimiter (default is whitespace ' ') to separte file names on the output::
+You can also specify a delimiter to separte file names displayed on the output (default is whitespace ' ')::
 
     # use ';' as a delimiter
     $ ufs ls ';'

--- a/tests/test_microfs.py
+++ b/tests/test_microfs.py
@@ -377,6 +377,21 @@ def test_ls():
             ["import os", "print(os.listdir())",], mock_serial
         )
 
+def test_ls_width_delimiter():
+    """
+    If a delimiter is provided, ensure that the result from stdout is equivalent
+    to the list Python .
+    """
+    mock_serial = mock.MagicMock()
+    with mock.patch(
+        "microfs.execute", return_value=(b"[ 'a.txt','b.txt']\r\n", b"")
+    ) as execute:
+        result = microfs.ls(mock_serial)
+        delimitedResult= ';'.join(result)
+        assert delimitedResult == "a.txt;b.txt"
+        execute.assert_called_once_with(
+            ["import os", "print(os.listdir())",], mock_serial
+        )
 
 def test_ls_with_error():
     """

--- a/tests/test_microfs.py
+++ b/tests/test_microfs.py
@@ -380,7 +380,7 @@ def test_ls():
 def test_ls_width_delimiter():
     """
     If a delimiter is provided, ensure that the result from stdout is equivalent
-    to the list Python .
+    to the list returned by Python.
     """
     mock_serial = mock.MagicMock()
     with mock.patch(


### PR DESCRIPTION
For completeness, I have implemented the test to check whether the list returned by the micro:bit using the command `ls` with  a specified delimiter is correct. The code boils down to the lines 389-391:

```python
result = microfs.ls(mock_serial)
delimitedResult= ';'.join(result)
assert delimitedResult == "a.txt;b.txt"
```
_The code above does not break any of the other tests or any of the microfs code._

Furthermore, I added to the README file the notion of using an optional delimiter from the command line.


## Note

The test above, though correct, is however superfluous as the test `test_ls` already checks whether the list of files returned by Python matches the stdout. The only difference is that, in the test I wrote, the resulting list is concatenated using a delimiter (an operation that happens in the test itself, rather than in the _microfs.ls_ function).  I created the test and send a pull request mainly for completeness, but this is **not** a critical issue.

