### PR TITLE
Change the pyserial version lock to a range in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pyflakes
 coverage
 sphinx
 pytest-cov
-pyserial==3.0.1
+pyserial>=3.0.1,<4.0
 
 # Mock is bundled as part of unittest since Python 3.3
 mock ; python_version == '2.7'


### PR DESCRIPTION
Otherwise it fails to run in macOS 11 Big Sur.