### PR TITLE
retry to enter raw repl

### DIFF
--- a/microfs.py
+++ b/microfs.py
@@ -69,7 +69,7 @@ def raw_on(serial):
         if not data.endswith(msg):
             if COMMAND_LINE_FLAG:
                 print(data)
-            raise IOError("Could not enter raw REPL.")
+            raise IOError("Could not enter raw REPL. %s" % data)
 
     def flush(serial):
         """Flush all rx input without relying on serial.flushInput()."""
@@ -93,9 +93,9 @@ def raw_on(serial):
             serial.write(b"\r\x01")
             flush_to_msg(serial, raw_repl_msg)
             break
-        except:
-            # retry on exception, ignore
-            pass
+        except Exception as ex:
+            if i == 2: # retrying did not help
+                raise ex
     # Soft Reset with CTRL-D
     serial.write(b"\x04")
     flush_to_msg(serial, b"soft reboot\r\n")

--- a/microfs.py
+++ b/microfs.py
@@ -87,8 +87,15 @@ def raw_on(serial):
         time.sleep(0.01)
     flush(serial)
     # Go into raw mode with CTRL-A.
-    serial.write(b"\r\x01")
-    flush_to_msg(serial, raw_repl_msg)
+    for i in range(3):
+        # retry to enter raw repl
+        try:
+            serial.write(b"\r\x01")
+            flush_to_msg(serial, raw_repl_msg)
+            break
+        except:
+            # retry on exception, ignore
+            pass
     # Soft Reset with CTRL-D
     serial.write(b"\x04")
     flush_to_msg(serial, b"soft reboot\r\n")


### PR DESCRIPTION
I had a problem, while listing the fs in mu-editor. They asked me to send the change request to the upstream module.
[retry to enter raw repl when listing fs](https://github.com/mu-editor/mu/pull/2378)